### PR TITLE
Revert "Do not update slot map after server EOF"

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -347,4 +347,5 @@ void server_eof(struct connection *server, const char *reason)
     // drop all unsent requests
     cmd_iov_free(&server->info->iov);
     conn_free(server);
+    slot_create_job(SLOT_UPDATE);
 }


### PR DESCRIPTION
Reverts eleme/corvus#61

`slot_create_job(SLOT_UPDATE);` is needed to recover from the death of nodes.