### PR TITLE
Fix: multiple key command dosen't have server, SIGSEGV on cmd_stats

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -917,7 +917,7 @@ void cmd_mark_fail(struct command *cmd, const char *reason)
 void cmd_stats(struct command *cmd, int64_t end_time)
 {
     struct context *ctx = cmd->ctx;
-    struct command *last, *first;
+    struct command *last, *first, *sub_cmd;
     long long latency;
 
     ATOMIC_INC(ctx->stats.completed_commands, 1);
@@ -929,7 +929,6 @@ void cmd_stats(struct command *cmd, int64_t end_time)
 
     if (config.slow_threshold >= 0 && latency > config.slow_threshold * 1000) {
       if (!STAILQ_EMPTY(&cmd->sub_cmds)) {
-	struct command *sub_cmd;
 	STAILQ_FOREACH(sub_cmd, &cmd->sub_cmds, sub_cmd_next) {
 	  ATOMIC_INC(sub_cmd->server->info->slow_cmd_counts[cmd->cmd_type], 1);	  
 	}

--- a/src/command.c
+++ b/src/command.c
@@ -928,7 +928,14 @@ void cmd_stats(struct command *cmd, int64_t end_time)
     ATOMIC_SET(ctx->last_command_latency, latency);
 
     if (config.slow_threshold >= 0 && latency > config.slow_threshold * 1000) {
-        ATOMIC_INC(cmd->server->info->slow_cmd_counts[cmd->cmd_type], 1);
+      if (!STAILQ_EMPTY(&cmd->sub_cmds)) {
+	struct command *sub_cmd;
+	STAILQ_FOREACH(sub_cmd, &cmd->sub_cmds, sub_cmd_next) {
+	  ATOMIC_INC(sub_cmd->server->info->slow_cmd_counts[cmd->cmd_type], 1);	  
+	}
+      } else {
+	ATOMIC_INC(cmd->server->info->slow_cmd_counts[cmd->cmd_type], 1);
+      }
     }
 
     if (!STAILQ_EMPTY(&cmd->sub_cmds)) {


### PR DESCRIPTION
  report slow log on each separate sub_cmd, still use latency of parent cmd
  latency in cmd_stats reflect time between receiving cmd from client till sending resp to client, it should apply to each sub_cmd.