### PR TITLE
Fix duplicate client_eof caused by connection timeout

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -342,6 +342,10 @@ struct connection *client_create(struct context *ctx, int fd)
 void client_eof(struct connection *client)
 {
     LOG(DEBUG, "client eof");
+    if (client->eof == true) {
+        LOG(ERROR, "client eof again");
+    }
+
     client->eof = true;
 
     struct command *cmd;


### PR DESCRIPTION
We have found the following logs in one of our running corvus:
```
2016-08-29 02:12:45,045 WARN [3348]: client '127.0.0.1:47576' timed out (timer.c:53)
2016-08-29 02:12:45,045 DEBUG [3348]: client eof (client.c:344)
2016-08-29 02:12:45,045 ERROR [3348]: event_deregister: 15 No such file or directory (event.c:88)
2016-08-29 02:12:45,045 ERROR [3348]: event_deregister: 16 No such file or directory (event.c:88)
2016-08-29 02:12:45,548 WARN [3348]: client '127.0.0.1:37176' timed out (timer.c:53)
2016-08-29 02:12:45,548 DEBUG [3348]: client eof (client.c:344)
2016-08-29 02:12:45,548 ERROR [3348]: event_deregister: 15 No such file or directory (event.c:88)
2016-08-29 02:12:45,548 ERROR [3348]: event_deregister: 16 No such file or directory (event.c:88)
2016-08-29 02:12:46,046 WARN [3348]: client '127.0.0.1:39411' timed out (timer.c:53)
2016-08-29 02:12:46,046 DEBUG [3348]: client eof (client.c:344)
2016-08-29 02:12:46,046 ERROR [3348]: event_deregister: 15 No such file or directory (event.c:88)
2016-08-29 02:12:46,046 ERROR [3348]: event_deregister: 16 No such file or directory (event.c:88)
```
The `client eof` messages are all followed by  two `event_deregister` in the log.

#### How does it happen?
It's caused by duplicate call of `client_eof` issued by connection timeout check.
When a client connection is holding some unfinished cmds and encounters a client_eof (caused by receiving an illegal redis packet for example), the client connection is turned into an intermediate state. It set all its cmds to `stale` and wait for all its cmds to be closed and then finally close itself. However before its cmds are closed, the timeout check may find this client connection and call client_eof again. This will result in negative `connected_clients`(#85) and the error log above.