### PR TITLE
Amend response format of 'proxy info'

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -414,16 +414,16 @@ int cmd_proxy_info(struct command *cmd)
     char content[n + 1];
     char data[n + 1];
     int content_len = snprintf(content, sizeof(content),
-        "in_use_buffers:%lld\n"
-        "free_buffers:%lld\n"
-        "in_use_cmds:%lld\n"
-        "free_cmds:%lld\n"
-        "in_use_conns:%lld\n"
-        "free_conns:%lld\n"
-        "in_use_conn_info:%lld\n"
-        "free_conn_info:%lld\n"
-        "in_use_buf_times:%lld\n"
-        "free_buf_times:%lld",
+        "in_use_buffers:%lld\r\n"
+        "free_buffers:%lld\r\n"
+        "in_use_cmds:%lld\r\n"
+        "free_cmds:%lld\r\n"
+        "in_use_conns:%lld\r\n"
+        "free_conns:%lld\r\n"
+        "in_use_conn_info:%lld\r\n"
+        "free_conn_info:%lld\r\n"
+        "in_use_buf_times:%lld\r\n"
+        "free_buf_times:%lld\r\n",
         stats.buffers, stats.free_buffers, stats.cmds, stats.free_cmds,
         stats.conns, stats.free_conns, stats.conn_info, stats.free_conn_info,
         stats.buf_times, stats.free_buf_times);


### PR DESCRIPTION
Let `proxy info` use the same format as `info`.