### PR TITLE
Bump version to v0.2.5

### DIFF
--- a/src/corvus.h
+++ b/src/corvus.h
@@ -14,7 +14,7 @@
 #include "event.h"
 #include "slowlog.h"
 
-#define VERSION "0.2.4"
+#define VERSION "0.2.5"
 
 #define CORVUS_OK 0
 #define CORVUS_ERR -1


### PR DESCRIPTION
#86 Randomly pick up the node used to update slots
#88 Fix duplicate client_eof caused by connection timeout
#87 Support slowlog command
#90 Add cluster name, pid, port to log
#91 Send slow command to statsd
#92 Use atomic operation to manipulate stats cumulation for safety
#93 Fix invalid resp in 'proxy info' command
#96 Amend response format of 'proxy info'
#94 Ignore command with error result in slowlog. Fix some bugs