### PR TITLE
Don't clear 'remotes' field from 'info' command during updating slot map

### DIFF
--- a/src/slot.h
+++ b/src/slot.h
@@ -31,8 +31,9 @@ struct node_desc {
 
 struct node_info {
     char name[64];
+    // contains master and slaves of one shard
     struct address nodes[MAX_SLAVE_NODES + 1];
-    size_t index;
+    size_t index;  // length of `nodes` above
     int refcount;
     // for parsing slots of a master node
     struct desc_part *slot_spec;


### PR DESCRIPTION
When the node list of corvus config file is wrong, once rebooted corvus can't retrieve the node list anymore. We need to find out this kind of corvus by checking whether the `remotes` field from `info` command is empty.
However, when corvus try updating its slot map, it will clear the its inner node list first, which will also result in empty `remotes` field before successfully retrieving the node list. So we can not tell whether there's something wrong with the node list of corvus even though there's empty `remotes`.
This PR changed this behavior. Now we only clear the node list after fail to update slot.