### PR TITLE
Fix crash after turning on slowlog at runtime

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -597,6 +597,8 @@ int cmd_config(struct command *cmd, struct redis_data *data)
             //config get <item>
             ASSERT_ELEMENTS(data->elements == 3, data);
             return cmd_config_get(cmd, option);
+        } else {
+            cmd_mark_fail(cmd, rep_config_err);
         }
     } else if (strcasecmp(type, "REWRITE") == 0) {
         return cmd_config_rewrite(cmd);

--- a/src/corvus.c
+++ b/src/corvus.c
@@ -215,7 +215,10 @@ void *main_loop(void *data)
 {
     struct context *ctx = data;
 
-    if (slowlog_cmd_enabled()) {
+    // Still initialize it no matter whether slowlog_log_slower_than
+    // is not negative so that we can turn on slowlog dynamically by
+    // changing slowlog_log_slower_than at runtime.
+    if (config.slowlog_max_len > 0) {
         LOG(DEBUG, "slowlog enabled");
         if (slowlog_init(&ctx->slowlog) == CORVUS_ERR) {
             LOG(ERROR, "Fatal: fail to init slowlog.");


### PR DESCRIPTION
#### How To Reproduce The Crash
(1) set `slowlog-max-len` to a positive value and `slowlog-log-slower-than` to -1 in config file.
(2) send `config set slowlog-log-slower-than 0` to corvus.
(3) execute any command that will be logged in slowlog such as `get key`.
(4) then it crash because of uninitialization of `slowlog_queue.entry_locks`.