### PR TITLE
Rename reserved identifier

### DIFF
--- a/src/corvus.h
+++ b/src/corvus.h
@@ -25,10 +25,10 @@
 #define CORVUS_ASKING -5
 #define CORVUS_READONLY -6
 
-#define RET_NOT_OK(expr)                   \
-    do {                                   \
-        int __r = expr;                    \
-        if (__r != CORVUS_OK) return __r;  \
+#define RET_NOT_OK(expr)               \
+    do {                               \
+        int r = expr;                  \
+        if (r != CORVUS_OK) return r;  \
     } while (0)
 
 


### PR DESCRIPTION
ISO/IEC 9899:2011
> — All identifiers that begin with an underscore and either an uppercase letter or another
underscore are always reserved for any use.
> — All identifiers that begin with an underscore are always reserved for use as identifiers
with file scope in both the ordinary and tag name spaces

----

Resolves #37 