### PR TITLE
fix for dict update same key after delete it

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -68,7 +68,7 @@ void dict_set(struct dict *dict, const char *key, void *data)
     while (1) {
         struct bucket *bucket = &dict->buckets[pos];
 
-        if (!bucket->setted) {
+        if (!bucket->setted || (bucket->deleted && bucket->hash == hash)) {
             set_bucket(bucket, hash, key, data);
             return;
         }


### PR DESCRIPTION
following calls will be fail:

dict_set(map, "test", "demo");
dict_delete(map, "test");
dict_set(map, "test", "new value"); //will not set it

this pr is submitted to fix it