### PR TITLE
Parse port until the end or to an @ symbol

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -319,7 +319,7 @@ int socket_parse_port(char *ptr, uint16_t *res)
 {
     char *end;
     int port = strtol(ptr, &end, 0);
-    if (*end != '\0' || port > 0xFFFF || port <= 0) return CORVUS_ERR;
+    if ((*end != '\0' && *end != '@') || port > 0xFFFF || port <= 0) return CORVUS_ERR;
     *res = port;
     return CORVUS_OK;
 }

--- a/tests/test_socket.c
+++ b/tests/test_socket.c
@@ -28,6 +28,9 @@ TEST(test_parse_port) {
 
     ASSERT(socket_parse_port("12345a", &port) == -1);
 
+    ASSERT(socket_parse_port("4242@12345", &port) == 0);
+    ASSERT(port == 4242);
+
     PASS(NULL);
 }
 
@@ -40,6 +43,10 @@ TEST(test_socket_parse_addr) {
     ASSERT(address.port == 8000);
 
     ASSERT(socket_parse_addr("234.233.1.1:65511", &address) == 65511);
+    ASSERT(strcmp(address.ip, "234.233.1.1") == 0);
+    ASSERT(address.port == 65511);
+
+    ASSERT(socket_parse_addr("234.233.1.1:65511@6379", &address) == 65511);
     ASSERT(strcmp(address.ip, "234.233.1.1") == 0);
     ASSERT(address.port == 65511);
 


### PR DESCRIPTION
Newer Redis Cluster includes the bus port in the output of `CLUSTER NODES`,
appened to the default ip:port tuple after an @ symbol.

Reference: https://github.com/antirez/redis/commit/b841f3ad1