### PR TITLE
Fix test_dump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ before_script:
   - ./src/corvus ./corvus.conf > corvus.log 2>&1 &
 
 script:
+  - redis-server -v
   - awk '/ERROR SUMMARY/ {if ($4 == 0) exit 0; else exit 1}' valgrind.log
   - make clean || true
   - make test

--- a/tests/test_corvus.py
+++ b/tests/test_corvus.py
@@ -131,9 +131,14 @@ def test_dump(delete_keys):
     redis>
     """
     delete_keys.keys("mykey")
+    node = ClusterNode.from_uri(REDIS_URI_SRC)
+    slot = node.execute_command("CLUSTER KEYSLOT", "mykey")
+    cluster = Cluster.from_node(node)
+    node = next((n for n in cluster.nodes if slot in n.slots), None)
+    assert node
 
     assert r.set("mykey", 10) is True
-    assert r.dump("mykey") == "\x00\xc0\n\x06\x00\xf8r?\xc5\xfb\xfb_("
+    assert r.dump("mykey") == node.dump("mykey")
 
 
 def test_exists(delete_keys):


### PR DESCRIPTION
The travis test `test_dump` failed due to the updating of `redis-server`.
Instead of hardcoding the `DUMP` result, get it from redis.