### PR TITLE
Fix slowlog crash when redirection fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,11 @@ install:
   - sudo redis-server /etc/redis/redis-cluster-8001.conf
   - sudo redis-server /etc/redis/redis-cluster-8002.conf
   - sudo redis-server /etc/redis/redis-cluster-8003.conf
+  - redis-server -v
 
+  - sudo pip install redis==2.10.5
   - sudo pip install ruskit
+  - pip freeze
   - ruskit create localhost:800{0,1,2}
 
   - sed -i 's/node localhost:8000,localhost:8001,localhost:8002/node 127.0.0.1:8000/' corvus.conf
@@ -49,7 +52,6 @@ before_script:
   - ./src/corvus ./corvus.conf > corvus.log 2>&1 &
 
 script:
-  - redis-server -v
   - awk '/ERROR SUMMARY/ {if ($4 == 0) exit 0; else exit 1}' valgrind.log
   - make clean || true
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ before_install:
   - sudo apt-get install -qq valgrind
 
 install:
+  - wget http://download.redis.io/releases/redis-3.0.7.tar.gz
+  - tar xzf redis-3.0.7.tar.gz
+  - cd redis-3.0.7
+  - make
+  - sudo cp src/redis-server `which redis-server`
+  - cd ../
+
   - sudo mkdir -p /etc/redis /var/lib/redis/cluster/{8000,8001,8002,8003}
 
   - sudo chmod -R 777 /etc/redis

--- a/src/command.c
+++ b/src/command.c
@@ -1120,9 +1120,13 @@ void cmd_mark(struct command *cmd, int fail)
         if (cmd->parent->cmd_done_count == cmd->parent->cmd_count) {
             root = cmd->parent;
         }
-        if (fail) {
-            cmd->parent->cmd_fail = true;
-        }
+        // In some cases cmd->cmd_fail is true though,
+        // cmd->parent->cmd_fail is not. But since `cmd_fail`
+        // implys a not null `fail_reason` (and maybe some other rules),
+        // now we keep it unchanged.
+        // if (fail) {
+        //     cmd->parent->cmd_fail = true;
+        // }
     }
 
     if (root != NULL && conn_register(root->client) == CORVUS_ERR) {

--- a/src/command.c
+++ b/src/command.c
@@ -1120,6 +1120,9 @@ void cmd_mark(struct command *cmd, int fail)
         if (cmd->parent->cmd_done_count == cmd->parent->cmd_count) {
             root = cmd->parent;
         }
+        if (fail) {
+            cmd->parent->cmd_fail = true;
+        }
     }
 
     if (root != NULL && conn_register(root->client) == CORVUS_ERR) {

--- a/src/slowlog.c
+++ b/src/slowlog.c
@@ -207,7 +207,6 @@ bool slowlog_need_log(struct command *cmd, long long latency)
 {
     int slowlog_log_slower_than = ATOMIC_GET(config.slowlog_log_slower_than);
     return slowlog_log_slower_than >= 0
-        && !cmd->cmd_fail
         && slowlog_type_need_log(cmd)
         // for those couldn't be forwarded and their cmd->data have been deallocated
         && cmd->data.elements > 0


### PR DESCRIPTION
Corvus may crash when it fails to connect to redis and try to create a sub-slowlog for multiple key command.
#### The Buggy Code
``` C
struct slowlog_entry *slowlog_create_sub_entry(struct command *cmd, int64_t total_latency)
{
    ...
    int64_t max_remote_latency = 0;
    struct command *c, *slowest_sub_cmd = NULL;
    STAILQ_FOREACH(c, &cmd->sub_cmds, sub_cmd_next) {
        // When this command fails because of not being able to connect to redis,
        // `remote_latency` will be zero (or maybe nagative) which result in a NULL `slowest_sub_cmd`.
        int64_t remote_latency = c->rep_time[1] - c->rep_time[0];
        if (remote_latency > max_remote_latency) {
            max_remote_latency = remote_latency;
            slowest_sub_cmd = c;
        }
    }
   // NULL `slowest_sub_cmd` will create a crash here.
    return slowlog_create_entry(slowest_sub_cmd, max_remote_latency / 1000, total_latency);
}
```

#### How To Reproduce
(1) Use the following Python 3 script to mock a redis cluster and let corvus connect to it.
Note that the `slowlog-log-slower-than` should be 0 and `slowlog-max-len` should be positive.
``` Python
import time
import socket

server_address = ('localhost', 10000)
sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
sock.bind(server_address)
sock.listen(1)

CLUSTER_NODES = b'*2\r\n$7\r\nCLUSTER\r\n$5\r\nNODES\r\n'
CLUSTER_NODES_RESP = 'ffffffffffffffffffff00000000490000000265 127.0.0.1:10000 myself,master - 0 0 1 connected 0-16383\n'
RESP = '${}\r\n{}\r\n'.format(len(CLUSTER_NODES_RESP), CLUSTER_NODES_RESP)

while True:
    connection, client_address = sock.accept()
    data = connection.recv(1000)
    if data == CLUSTER_NODES:
        connection.sendall(RESP.encode('utf-8'))
        raise Exception('Let it crash')
````
(2) Send a `MGET SomeKey` to corvus and trigger a crash.

Now we're about to stop corvus from logging commands with `cmd_fail` flag.
We will test this fix and release a new version this week.