### PR TITLE
Bump version to 0.2.7

### DIFF
--- a/src/corvus.h
+++ b/src/corvus.h
@@ -15,7 +15,7 @@
 #include "slowlog.h"
 #include "config.h"
 
-#define VERSION "0.2.6"
+#define VERSION "0.2.7"
 
 #define CORVUS_OK 0
 #define CORVUS_ERR -1


### PR DESCRIPTION
This version is mainly for:
- Crash fix in SLOWLOG #129 
- Compatibility support for the new format of `CLUSTER NODES`, which makes corvus be able to work with Redis 4.0 now #124 