### PR TITLE
Preferred nodes

### DIFF
--- a/corvus.conf
+++ b/corvus.conf
@@ -57,12 +57,29 @@ syslog 0
 #
 #   * `master`, forward all reading commands to master, the default
 #   * `read-slave-only`, forward all reading commands to slaves
+#   * `read-preferred-only` forward all reading commands to a slave or master based on the preferred_node list
 #   * `both`, forward reading commands to both master and slaves
 #
 # If new slaves are added to the cluster, `PROXY UPDATESLOTMAP` should be emmited
 # to tell corvus to use the newly added slaves.
 #
 # read-strategy master
+
+#
+# When the `read-preferred-only` strategy is configured, the nodes from the `preferred_nodes` list
+# will be preferred to any other node for a given slot.
+# This is useful if a cluster is distributed geographically. It can be preferable to query the local nodes
+# If the cluster shows a preferred node as disconnected, it won't be used but the cluster status will be
+# polled until all preferred nodes are available again.
+#
+# preferred_nodes localhost:8003,localhost:8004
+
+#
+# When `read-preferred` read-strategy is used and the cluster shows a preferred node to be disconnected,
+# an active polling of the cluster configuration is started to determine as soon as possible when the
+# preferred node is back online so that it can be used again.
+#
+polling_interval 30
 
 # Slowlog
 # The following two configs are almost the same with redis.

--- a/src/config.h
+++ b/src/config.h
@@ -17,6 +17,7 @@ struct corvus_config {
     char cluster[CLUSTER_NAME_SIZE + 1];
     uint16_t bind;
     struct node_conf *node;
+	struct node_conf *preferred_node; /* List of nodes that should be set a higher priority */
     int thread;
     int loglevel;
     bool syslog;
@@ -25,6 +26,8 @@ struct corvus_config {
     bool stats;
     bool readslave;
     bool readmasterslave;
+    bool readpreferred;
+    uint16_t polling_interval; /* Intervall to use when polling for cluster configuration */
     char *requirepass;
     int64_t client_timeout;
     int64_t server_timeout;
@@ -46,5 +49,7 @@ void config_set_node(struct node_conf *node);
 void config_node_dec_ref(struct node_conf *node);
 int config_add(char *name, char *value);
 bool config_option_changable(const char *option);
+struct node_conf *config_get_preferred_node();
+bool config_is_preferred_node(struct address *node);
 
 #endif /* end of include guard: CONFIG_H */

--- a/src/server.c
+++ b/src/server.c
@@ -254,9 +254,15 @@ int server_read(struct connection *server)
                 cmd->asking = 0;
                 continue;
             case CORVUS_READONLY:
-                LOG(DEBUG, "recv readonly");
+                if (cmd->reply_type == REP_ERROR) {
+                    LOG(ERROR, "recv invalid readonly reponse");
+                    info->readonly = true;
+                } else {
+                    LOG(DEBUG, "recv readonly");
+                }
+               
                 mbuf_range_clear(cmd->ctx, cmd->rep_buf);
-                server->info->readonly_sent = false;
+                info->readonly_sent = false;
                 continue;
             case CORVUS_OK:
                 STAILQ_REMOVE_HEAD(&info->waiting_queue, waiting_next);

--- a/src/slot.h
+++ b/src/slot.h
@@ -30,11 +30,18 @@ struct node_desc {
     uint16_t index, len;
 };
 
+struct node {
+    struct address addr;
+    bool available;
+};
+
 struct node_info {
     char name[64];
-    // contains master and slaves of one shard
-    struct address nodes[MAX_SLAVE_NODES + 1];
+    // contains preferred node (if exists), master and slaves of one shard
+    struct node nodes[MAX_SLAVE_NODES + 1];
     size_t index;  // length of `nodes` above
+    struct node preferred_nodes[MAX_SLAVE_NODES + 1];
+    size_t preferred_index;  // length of `preferred_nodes` above
     int refcount;
     // for parsing slots of a master node
     struct desc_part *slot_spec;

--- a/src/socket.c
+++ b/src/socket.c
@@ -391,3 +391,8 @@ int socket_trigger_event(int evfd)
     }
     return CORVUS_OK;
 }
+
+int socket_cmp(struct address *a, struct address *b)
+{
+    return strcmp(a->ip, b->ip) || a->port != b->port;
+}

--- a/src/socket.h
+++ b/src/socket.h
@@ -33,5 +33,6 @@ int socket_parse_addr(char *addr, struct address *address);
 int socket_parse_ip(char *addr, struct address *address);
 int socket_create_eventfd();
 int socket_trigger_event(int evfd);
+int socket_cmp(struct address *a, struct address *b);
 
 #endif /* end of include guard: SOCKET_H */

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -45,11 +45,13 @@ TEST(test_config_read_strategy) {
     char n[] = "read-strategy";
 
     ASSERT(config_add(n, "read-slave-only") == 0);
-    ASSERT(config.readslave && !config.readmasterslave);
+    ASSERT(config.readslave && !config.readmasterslave && !config.readpreferred);
     ASSERT(config_add(n, "both") == 0);
-    ASSERT(config.readslave && config.readmasterslave);
+    ASSERT(config.readslave && config.readmasterslave && !config.readpreferred);
     ASSERT(config_add(n, "master") == 0);
-    ASSERT(!config.readslave && !config.readmasterslave);
+    ASSERT(!config.readslave && !config.readmasterslave && !config.readpreferred);
+    ASSERT(config_add(n, "read-preferred") == 0);
+    ASSERT(!config.readslave && !config.readmasterslave && config.readpreferred);
 
     PASS(NULL);
 }

--- a/tests/test_socket.c
+++ b/tests/test_socket.c
@@ -65,9 +65,24 @@ TEST(test_socket_parse_addr_wrong) {
     PASS(NULL);
 }
 
+TEST(test_socket_compare) {
+    struct address addr1;
+    struct address addr2;
+    socket_parse_addr("127.0.0.1:12345", &addr1);
+    socket_parse_addr("127.0.0.1:12345", &addr2);
+    ASSERT(socket_cmp(&addr1, &addr2) == 0);
+
+    socket_parse_addr("127.0.0.1:1234", &addr2);
+    ASSERT(socket_cmp(&addr1, &addr2) == 1);
+
+    socket_parse_addr("127.0.0.2:12345", &addr2);
+    ASSERT(socket_cmp(&addr1, &addr2) == 1);
+}
+
 TEST_CASE(test_socket) {
     RUN_TEST(test_socket_address_init);
     RUN_TEST(test_parse_port);
     RUN_TEST(test_socket_parse_addr);
     RUN_TEST(test_socket_parse_addr_wrong);
+    RUN_TEST(test_socket_compare);
 }


### PR DESCRIPTION
Allow preferred nodes to be configured

If a cluster is distributed geographically, it can be preferable to query the local nodes. For readonly commands, preferred nodes let us chose a subset of the cluster nodes that will be prioritised when choosing a node. A specific local slave can therefore be used.