### PR TITLE
docs: fix simple typo, quanlity -> quality

### DIFF
--- a/docs/lpt.md
+++ b/docs/lpt.md
@@ -30,7 +30,7 @@ Redis(3.0.3): 3 dedicated server with 60 nodes, in which 30 are masters.
 ## Tests
 
 Note: The following tests are carried out in extreme load, focused
-on how much load it can operate on, in disregard of service quanlity(return time).
+on how much load it can operate on, in disregard of service quality(return time).
 
 
 1. [set](redis_benchmarks/set.md)


### PR DESCRIPTION
There is a small typo in docs/lpt.md.

Should read `quality` rather than `quanlity`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md